### PR TITLE
Do not trace .ts files in node_modules

### DIFF
--- a/src/node-file-trace.js
+++ b/src/node-file-trace.js
@@ -156,7 +156,8 @@ class Job {
     await Promise.all([
       ...[...assets].map(async asset => {
         const ext = extname(asset);
-        if (ext === '.js' || ext === '.mjs' || ext === '.node' || ext === '' || this.ts && ext === '.ts')
+        if (ext === '.js' || ext === '.mjs' || ext === '.node' || ext === '' ||
+            this.ts && ext === '.ts' && asset.startsWith(this.base) && asset.substr(this.base.length).indexOf(sep + 'node_modules' + sep) === -1)
           await this.emitDependency(asset, path);
         else
           this.emitFile(asset, 'asset', path);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -8,6 +8,7 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
     const unitPath = `${__dirname}/unit/${unitTest}`;
     const { fileList, reasons } = await nodeFileTrace([`${unitPath}/input.js`], {
       base: `${__dirname}/unit`,
+      ts: true,
       filterBase: false,
       ignore: '**/actual.js'
     });

--- a/test/unit/ts-filter/actual.js
+++ b/test/unit/ts-filter/actual.js
@@ -1,0 +1,6 @@
+[
+  "ts-filter/input.js",
+  "ts-filter/node_modules/pkg/dep.js",
+  "ts-filter/node_modules/pkg/index.js",
+  "ts-filter/node_modules/pkg/index.ts"
+]

--- a/test/unit/ts-filter/actual.js
+++ b/test/unit/ts-filter/actual.js
@@ -1,6 +1,0 @@
-[
-  "ts-filter/input.js",
-  "ts-filter/node_modules/pkg/dep.js",
-  "ts-filter/node_modules/pkg/index.js",
-  "ts-filter/node_modules/pkg/index.ts"
-]

--- a/test/unit/ts-filter/input.js
+++ b/test/unit/ts-filter/input.js
@@ -1,0 +1,5 @@
+require('pkg');
+
+// asset reference to ts file in node_modules
+// should not cause ts file to be compiled
+fs.readFileSync(__dirname + '/node_modules/pkg/index.ts');

--- a/test/unit/ts-filter/node_modules/pkg/dep.js
+++ b/test/unit/ts-filter/node_modules/pkg/dep.js
@@ -1,0 +1,2 @@
+console.log('should not be traced');
+

--- a/test/unit/ts-filter/node_modules/pkg/index.js
+++ b/test/unit/ts-filter/node_modules/pkg/index.js
@@ -1,0 +1,1 @@
+module.exports = 'main';

--- a/test/unit/ts-filter/node_modules/pkg/index.ts
+++ b/test/unit/ts-filter/node_modules/pkg/index.ts
@@ -1,0 +1,1 @@
+import './dep';

--- a/test/unit/ts-filter/output.js
+++ b/test/unit/ts-filter/output.js
@@ -1,0 +1,5 @@
+[
+  "ts-filter/input.js",
+  "ts-filter/node_modules/pkg/index.js",
+  "ts-filter/node_modules/pkg/index.ts"
+]


### PR DESCRIPTION
This fixes up the `ts: true` option (which affects the resolver and tracing to support `.ts` files) to ensure that `.ts` files emitted as assets are not in turn traced as dependencies when they are contained in `node_modules`.

This should, with some luck, fix the current front issue.