### PR TITLE
Set default `base` to `process.cwd()`, deprecate `filterBase` option

### DIFF
--- a/node-file-trace.d.ts
+++ b/node-file-trace.d.ts
@@ -1,6 +1,5 @@
 interface NodeFileTraceOptions {
   base?: string;
-  filterBase?: boolean;
   ignore?: string | string[] | ((path: string) => boolean);
   ts?: boolean;
   log?: boolean;

--- a/readme.md
+++ b/readme.md
@@ -30,28 +30,15 @@ The list of files will include all `node_modules` modules and assets that may be
 
 The base path for the file list - all files will be provided as relative to this base.
 
+By default the `process.cwd()` is used:
+
 ```js
 const { fileList } = await nodeFileTrace(files, {
   base: process.cwd()
 }
 ```
 
-If no base is provided, absolute paths are always output.
-
-By default any files below the `base` are ignored in the listing and analysis.
-
-#### FilterBase
-
-Boolean, defaults to true.
-
-```js
-const { fileList } = await nodeFileTrace(files, {
-  base: process.cwd(),
-  filterBase: false
-}
-```
-
-By setting this to `false`, it allows opting out of excluding any files below the `base` path in the list.
+Any files below the `base` are ignored in the listing and analysis.
 
 #### Ignore
 

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -154,7 +154,7 @@ module.exports = async function (id, code, job) {
   const dir = path.dirname(id);
   // if (typeof options.production === 'boolean' && staticProcess.env.NODE_ENV === UNKNOWN)
   //  staticProcess.env.NODE_ENV = options.production ? 'production' : 'dev';
-  cwd = job.base || process.cwd();
+  cwd = job.base;
   const pkgBase = getPackageBase(id);
 
   const emitAssetDirectory = (wildcardPath) => {
@@ -166,7 +166,7 @@ module.exports = async function (id, code, job) {
       return patternPath[index - 1] === path.sep ? '**/*' : '*';
     }).replace(repeatGlobRegEx, '/**/*') || '/**/*';
 
-    if (job.ignoreFn(job.base ? path.relative(job.base, assetDirPath + wildcardPattern) : assetDirPath + wildcardPattern, id))
+    if (job.ignoreFn(path.relative(job.base, assetDirPath + wildcardPattern)))
       return;
 
     assetEmissionPromises = assetEmissionPromises.then(async () => {
@@ -320,7 +320,7 @@ module.exports = async function (id, code, job) {
     if (!wildcardPattern.endsWith('*'))
       wildcardPattern += '?(' + (job.ts ? '.ts|' : '') + '.js|.json|.node)';
 
-    if (job.ignoreFn(job.base ? path.relative(job.base, wildcardDirPath + wildcardPattern) : wildcardDirPath + wildcardPattern, id))
+    if (job.ignoreFn(path.relative(job.base, wildcardDirPath + wildcardPattern)))
       return;
 
     assetEmissionPromises = assetEmissionPromises.then(async () => {

--- a/src/node-file-trace.js
+++ b/src/node-file-trace.js
@@ -37,26 +37,19 @@ module.exports = async function (files, opts = {}) {
 
 class Job {
   constructor ({
-    base,
-    filterBase,
+    base = process.cwd(),
     ignore,
     log = false
   }) {
-    if (base) {
-      if (filterBase !== false) filterBase = true;
-      base = resolve(base);
-    }
-    else {
-      filterBase = false;
-    }
+    base = resolve(base);
     this.ignoreFn = path => {
-      if (filterBase && path.startsWith('..' + sep)) return true;
+      if (path.startsWith('..' + sep)) return true;
       return false;
     };
     if (typeof ignore === 'string') ignore = [ignore];
     if (typeof ignore === 'function') {
       this.ignoreFn = path => {
-        if (filterBase && path.startsWith('..' + sep)) return true;
+        if (path.startsWith('..' + sep)) return true;
         if (ignore(path)) return true;
         return false;
       };
@@ -64,7 +57,7 @@ class Job {
     else if (Array.isArray(ignore)) {
       const resolvedIgnores = ignore.map(ignore => relative(base, resolve(base || process.cwd(), ignore)));
       this.ignoreFn = path => {
-        if (filterBase && path.startsWith('..' + sep)) return true;
+        if (path.startsWith('..' + sep)) return true;
         if (isMatch(path, resolvedIgnores)) return true;
         return false;
       }
@@ -140,11 +133,9 @@ class Job {
 
   emitFile (path, reason, parent) {
     if (this.fileList.has(path)) return;
-    if (this.base) {
-      path = relative(this.base, path);
-      if (parent)
-        parent = relative(this.base, parent);
-    }
+    path = relative(this.base, path);
+    if (parent)
+      parent = relative(this.base, parent);
     const reasonEntry = this.reasons[path] || (this.reasons[path] = {
       type: reason,
       ignored: false,
@@ -175,7 +166,7 @@ class Job {
 
     const { deps, assets, isESM } = await analyze(path, source, this);
     if (isESM)
-      this.esmFileList.add(this.base ? relative(this.base, path) : path);
+      this.esmFileList.add(relative(this.base, path));
     await Promise.all([
       ...[...assets].map(async asset => {
         const ext = extname(asset);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -21,10 +21,9 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
   it(`should correctly trace ${unitTest}`, async () => {
     const unitPath = `${__dirname}/unit/${unitTest}`;
     const { fileList, reasons } = await nodeFileTrace([`${unitPath}/input.js`], {
-      base: `${__dirname}/unit`,
+      base: `${__dirname}/../`,
       ts: true,
       log: true,
-      filterBase: false,
       ignore: '**/actual.js'
     });
     let expected;

--- a/test/unit/amd-disable/output.js
+++ b/test/unit/amd-disable/output.js
@@ -1,3 +1,3 @@
 [
-  "amd-disable/input.js"
+  "test/unit/amd-disable/input.js"
 ]

--- a/test/unit/array-emission/output.js
+++ b/test/unit/array-emission/output.js
@@ -1,5 +1,5 @@
 [
-  "array-emission/input.js",
-  "array-emission/renderer/dom.js",
-  "array-emission/renderer/util.js"
+  "test/unit/array-emission/input.js",
+  "test/unit/array-emission/renderer/dom.js",
+  "test/unit/array-emission/renderer/util.js"
 ]

--- a/test/unit/array-holes/output.js
+++ b/test/unit/array-holes/output.js
@@ -1,3 +1,3 @@
 [
-  "array-holes/input.js"
+  "test/unit/array-holes/input.js"
 ]

--- a/test/unit/asset-conditional/output.js
+++ b/test/unit/asset-conditional/output.js
@@ -1,5 +1,5 @@
 [
-  "asset-conditional/asset1.txt",
-  "asset-conditional/asset2.txt",
-  "asset-conditional/input.js"
+  "test/unit/asset-conditional/asset1.txt",
+  "test/unit/asset-conditional/asset2.txt",
+  "test/unit/asset-conditional/input.js"
 ]

--- a/test/unit/asset-fs-inline-path-enc-es-2/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-2/output.js
@@ -1,4 +1,4 @@
 [
-  "asset-fs-inline-path-enc-es-2/asset.txt",
-  "asset-fs-inline-path-enc-es-2/input.js"
+  "test/unit/asset-fs-inline-path-enc-es-2/asset.txt",
+  "test/unit/asset-fs-inline-path-enc-es-2/input.js"
 ]

--- a/test/unit/asset-fs-inline-path-enc-es-3/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-3/output.js
@@ -1,4 +1,4 @@
 [
-  "asset-fs-inline-path-enc-es-3/asset.txt",
-  "asset-fs-inline-path-enc-es-3/input.js"
+  "test/unit/asset-fs-inline-path-enc-es-3/asset.txt",
+  "test/unit/asset-fs-inline-path-enc-es-3/input.js"
 ]

--- a/test/unit/asset-fs-inline-path-enc-es-4/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-4/output.js
@@ -1,4 +1,4 @@
 [
-  "asset-fs-inline-path-enc-es-4/asset.txt",
-  "asset-fs-inline-path-enc-es-4/input.js"
+  "test/unit/asset-fs-inline-path-enc-es-4/asset.txt",
+  "test/unit/asset-fs-inline-path-enc-es-4/input.js"
 ]

--- a/test/unit/asset-fs-inline-path-enc-es-5/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-5/output.js
@@ -1,4 +1,4 @@
 [
-  "asset-fs-inline-path-enc-es-5/asset.txt",
-  "asset-fs-inline-path-enc-es-5/input.js"
+  "test/unit/asset-fs-inline-path-enc-es-5/asset.txt",
+  "test/unit/asset-fs-inline-path-enc-es-5/input.js"
 ]

--- a/test/unit/asset-fs-inline-path-enc-es/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es/output.js
@@ -1,4 +1,4 @@
 [
-  "asset-fs-inline-path-enc-es/asset.txt",
-  "asset-fs-inline-path-enc-es/input.js"
+  "test/unit/asset-fs-inline-path-enc-es/asset.txt",
+  "test/unit/asset-fs-inline-path-enc-es/input.js"
 ]

--- a/test/unit/asset-fs-inline-path-shadow/output.js
+++ b/test/unit/asset-fs-inline-path-shadow/output.js
@@ -1,4 +1,4 @@
 [
-  "asset-fs-inline-path-shadow/asset.txt",
-  "asset-fs-inline-path-shadow/input.js"
+  "test/unit/asset-fs-inline-path-shadow/asset.txt",
+  "test/unit/asset-fs-inline-path-shadow/input.js"
 ]

--- a/test/unit/asset-fs-inline-tpl/output.js
+++ b/test/unit/asset-fs-inline-tpl/output.js
@@ -1,4 +1,4 @@
 [
-  "asset-fs-inline-tpl/asset.txt",
-  "asset-fs-inline-tpl/input.js"
+  "test/unit/asset-fs-inline-tpl/asset.txt",
+  "test/unit/asset-fs-inline-tpl/input.js"
 ]

--- a/test/unit/asset-fs-inlining-multi/output.js
+++ b/test/unit/asset-fs-inlining-multi/output.js
@@ -1,5 +1,5 @@
 [
-  "asset-fs-inlining-multi/asset.txt",
-  "asset-fs-inlining-multi/input.js",
-  "asset-fs-inlining-multi/sub/asset.txt"
+  "test/unit/asset-fs-inlining-multi/asset.txt",
+  "test/unit/asset-fs-inlining-multi/input.js",
+  "test/unit/asset-fs-inlining-multi/sub/asset.txt"
 ]

--- a/test/unit/asset-fs-inlining/output.js
+++ b/test/unit/asset-fs-inlining/output.js
@@ -1,4 +1,4 @@
 [
-  "asset-fs-inlining/asset.txt",
-  "asset-fs-inlining/input.js"
+  "test/unit/asset-fs-inlining/asset.txt",
+  "test/unit/asset-fs-inlining/input.js"
 ]

--- a/test/unit/asset-fs-logical/output.js
+++ b/test/unit/asset-fs-logical/output.js
@@ -1,5 +1,5 @@
 [
-  "asset-fs-logical/asset1.txt",
-  "asset-fs-logical/asset2.txt",
-  "asset-fs-logical/input.js"
+  "test/unit/asset-fs-logical/asset1.txt",
+  "test/unit/asset-fs-logical/asset2.txt",
+  "test/unit/asset-fs-logical/input.js"
 ]

--- a/test/unit/asset-node-require/output.js
+++ b/test/unit/asset-node-require/output.js
@@ -1,4 +1,4 @@
 [
-  "asset-node-require/input.js",
-  "asset-node-require/mock.node"
+  "test/unit/asset-node-require/input.js",
+  "test/unit/asset-node-require/mock.node"
 ]

--- a/test/unit/asset-package-json/output.js
+++ b/test/unit/asset-package-json/output.js
@@ -1,4 +1,4 @@
 [
-  "asset-package-json/input.js",
-  "asset-package-json/package.json"
+  "test/unit/asset-package-json/input.js",
+  "test/unit/asset-package-json/package.json"
 ]

--- a/test/unit/browserify-uglify/output.js
+++ b/test/unit/browserify-uglify/output.js
@@ -1,5 +1,5 @@
 [
-  "browserify-uglify/dep1.js",
-  "browserify-uglify/dep2.js",
-  "browserify-uglify/input.js"
+  "test/unit/browserify-uglify/dep1.js",
+  "test/unit/browserify-uglify/dep2.js",
+  "test/unit/browserify-uglify/input.js"
 ]

--- a/test/unit/browserify/output.js
+++ b/test/unit/browserify/output.js
@@ -1,5 +1,5 @@
 [
-  "browserify/dep1.js",
-  "browserify/dep2.js",
-  "browserify/input.js"
+  "test/unit/browserify/dep1.js",
+  "test/unit/browserify/dep2.js",
+  "test/unit/browserify/input.js"
 ]

--- a/test/unit/dirname-emit/output.js
+++ b/test/unit/dirname-emit/output.js
@@ -1,3 +1,3 @@
 [
-  "dirname-emit/input.js"
+  "test/unit/dirname-emit/input.js"
 ]

--- a/test/unit/dirname-len/output.js
+++ b/test/unit/dirname-len/output.js
@@ -1,3 +1,3 @@
 [
-  "dirname-len/input.js"
+  "test/unit/dirname-len/input.js"
 ]

--- a/test/unit/esm/output.js
+++ b/test/unit/esm/output.js
@@ -1,7 +1,7 @@
 [
-  "../../node_modules/esm/esm.js",
-  "../../node_modules/esm/esm/loader.js",
-  "../../node_modules/esm/package.json",
-  "esm/esm-dep.js",
-  "esm/input.js"
+  "node_modules/esm/esm.js",
+  "node_modules/esm/esm/loader.js",
+  "node_modules/esm/package.json",
+  "test/unit/esm/esm-dep.js",
+  "test/unit/esm/input.js"
 ]

--- a/test/unit/ffmpeg-installer/output.js
+++ b/test/unit/ffmpeg-installer/output.js
@@ -1,5 +1,5 @@
 [
-  "ffmpeg-installer/ffmpeg.exe",
-  "ffmpeg-installer/ffmpeg.js",
-  "ffmpeg-installer/input.js"
+  "test/unit/ffmpeg-installer/ffmpeg.exe",
+  "test/unit/ffmpeg-installer/ffmpeg.js",
+  "test/unit/ffmpeg-installer/input.js"
 ]

--- a/test/unit/filter-asset-base/output.js
+++ b/test/unit/filter-asset-base/output.js
@@ -1,4 +1,4 @@
 [
-  "../../package.json",
-  "filter-asset-base/input.js"
+  "package.json",
+  "test/unit/filter-asset-base/input.js"
 ]

--- a/test/unit/fs-emission/output.js
+++ b/test/unit/fs-emission/output.js
@@ -1,5 +1,5 @@
 [
-  "fs-emission/asset2.txt",
-  "fs-emission/asset3.txt",
-  "fs-emission/input.js"
+  "test/unit/fs-emission/asset2.txt",
+  "test/unit/fs-emission/asset3.txt",
+  "test/unit/fs-emission/input.js"
 ]

--- a/test/unit/module-require/output.js
+++ b/test/unit/module-require/output.js
@@ -1,4 +1,4 @@
 [
-  "module-require/dep.js",
-  "module-require/input.js"
+  "test/unit/module-require/dep.js",
+  "test/unit/module-require/input.js"
 ]

--- a/test/unit/mongoose/output.js
+++ b/test/unit/mongoose/output.js
@@ -1,4 +1,4 @@
 [
-  "mongoose/dir/connection.js",
-  "mongoose/input.js"
+  "test/unit/mongoose/dir/connection.js",
+  "test/unit/mongoose/input.js"
 ]

--- a/test/unit/node-modules-filter/output.js
+++ b/test/unit/node-modules-filter/output.js
@@ -1,3 +1,3 @@
 [
-  "node-modules-filter/input.js"
+  "test/unit/node-modules-filter/input.js"
 ]

--- a/test/unit/non-analyzable-requires/output.js
+++ b/test/unit/non-analyzable-requires/output.js
@@ -1,4 +1,4 @@
 [
-  "non-analyzable-requires/dep.js",
-  "non-analyzable-requires/input.js"
+  "test/unit/non-analyzable-requires/dep.js",
+  "test/unit/non-analyzable-requires/input.js"
 ]

--- a/test/unit/null-destructure/output.js
+++ b/test/unit/null-destructure/output.js
@@ -1,3 +1,3 @@
 [
-  "null-destructure/input.js"
+  "test/unit/null-destructure/input.js"
 ]

--- a/test/unit/path-sep/output.js
+++ b/test/unit/path-sep/output.js
@@ -1,4 +1,4 @@
 [
-  "path-sep/asset.txt",
-  "path-sep/input.js"
+  "test/unit/path-sep/asset.txt",
+  "test/unit/path-sep/input.js"
 ]

--- a/test/unit/pkginfo/output.js
+++ b/test/unit/pkginfo/output.js
@@ -1,4 +1,4 @@
 [
-  "pkginfo/input.js",
-  "pkginfo/package.json"
+  "test/unit/pkginfo/input.js",
+  "test/unit/pkginfo/package.json"
 ]

--- a/test/unit/prisma-photon/output.js
+++ b/test/unit/prisma-photon/output.js
@@ -1,5 +1,5 @@
 [
-  "prisma-photon/input.js",
-  "prisma-photon/node_modules/@generated/photon/index.js",
-  "prisma-photon/node_modules/@generated/photon/runtime/prisma"
+  "test/unit/prisma-photon/input.js",
+  "test/unit/prisma-photon/node_modules/@generated/photon/index.js",
+  "test/unit/prisma-photon/node_modules/@generated/photon/runtime/prisma"
 ]

--- a/test/unit/process-env/output.js
+++ b/test/unit/process-env/output.js
@@ -1,5 +1,5 @@
 [
-  "process-env/a.js",
-  "process-env/b.js",
-  "process-env/input.js"
+  "test/unit/process-env/a.js",
+  "test/unit/process-env/b.js",
+  "test/unit/process-env/input.js"
 ]

--- a/test/unit/protobuf-loop/output.js
+++ b/test/unit/protobuf-loop/output.js
@@ -1,5 +1,5 @@
 [
-    "protobuf-loop/assets/asset1.txt",
-    "protobuf-loop/assets/asset2.txt",
-    "protobuf-loop/input.js"
-  ]
+  "test/unit/protobuf-loop/assets/asset1.txt",
+  "test/unit/protobuf-loop/assets/asset2.txt",
+  "test/unit/protobuf-loop/input.js"
+]

--- a/test/unit/protobuf-loop2/output.js
+++ b/test/unit/protobuf-loop2/output.js
@@ -1,5 +1,5 @@
 [
-  "protobuf-loop2/assets/asset1.txt",
-  "protobuf-loop2/assets/asset2.txt",
-  "protobuf-loop2/input.js"
+  "test/unit/protobuf-loop2/assets/asset1.txt",
+  "test/unit/protobuf-loop2/assets/asset2.txt",
+  "test/unit/protobuf-loop2/input.js"
 ]

--- a/test/unit/require-call/output.js
+++ b/test/unit/require-call/output.js
@@ -1,3 +1,3 @@
 [
-  "require-call/input.js"
+  "test/unit/require-call/input.js"
 ]

--- a/test/unit/require-dirname-tpl/output.js
+++ b/test/unit/require-dirname-tpl/output.js
@@ -1,4 +1,4 @@
 [
-  "require-dirname-tpl/dep.js",
-  "require-dirname-tpl/input.js"
+  "test/unit/require-dirname-tpl/dep.js",
+  "test/unit/require-dirname-tpl/input.js"
 ]

--- a/test/unit/require-dynamic-fallback/output.js
+++ b/test/unit/require-dynamic-fallback/output.js
@@ -1,4 +1,4 @@
 [
-  "require-dynamic-fallback/dep.js",
-  "require-dynamic-fallback/input.js"
+  "test/unit/require-dynamic-fallback/dep.js",
+  "test/unit/require-dynamic-fallback/input.js"
 ]

--- a/test/unit/require-empty/output.js
+++ b/test/unit/require-empty/output.js
@@ -1,3 +1,3 @@
 [
-  "require-empty/input.js"
+  "test/unit/require-empty/input.js"
 ]

--- a/test/unit/require-esm/output.js
+++ b/test/unit/require-esm/output.js
@@ -1,3 +1,3 @@
 [
-  "require-esm/input.js"
+  "test/unit/require-esm/input.js"
 ]

--- a/test/unit/require-resolve/output.js
+++ b/test/unit/require-resolve/output.js
@@ -1,6 +1,6 @@
 [
-  "require-resolve/asset1.txt",
-  "require-resolve/asset2.txt",
-  "require-resolve/asset3.txt",
-  "require-resolve/input.js"
+  "test/unit/require-resolve/asset1.txt",
+  "test/unit/require-resolve/asset2.txt",
+  "test/unit/require-resolve/asset3.txt",
+  "test/unit/require-resolve/input.js"
 ]

--- a/test/unit/require-symlink/output.js
+++ b/test/unit/require-symlink/output.js
@@ -1,5 +1,5 @@
 [
-  "require-symlink/another.js",
-  "require-symlink/input.js",
-  "require-symlink/symlink"
+  "test/unit/require-symlink/another.js",
+  "test/unit/require-symlink/input.js",
+  "test/unit/require-symlink/symlink"
 ]

--- a/test/unit/require-wrapper/output.js
+++ b/test/unit/require-wrapper/output.js
@@ -1,4 +1,4 @@
 [
-  "require-wrapper/dep.js",
-  "require-wrapper/input.js"
+  "test/unit/require-wrapper/dep.js",
+  "test/unit/require-wrapper/input.js"
 ]

--- a/test/unit/require-wrapper2/output.js
+++ b/test/unit/require-wrapper2/output.js
@@ -1,4 +1,4 @@
 [
-  "require-wrapper2/dep.js",
-  "require-wrapper2/input.js"
+  "test/unit/require-wrapper2/dep.js",
+  "test/unit/require-wrapper2/input.js"
 ]

--- a/test/unit/require-wrapper3/output.js
+++ b/test/unit/require-wrapper3/output.js
@@ -1,4 +1,4 @@
 [
-  "require-wrapper3/dep.js",
-  "require-wrapper3/input.js"
+  "test/unit/require-wrapper3/dep.js",
+  "test/unit/require-wrapper3/input.js"
 ]

--- a/test/unit/resolve-from/output.js
+++ b/test/unit/resolve-from/output.js
@@ -1,5 +1,5 @@
 [
-  "../../node_modules/resolve-from/index.js",
-  "resolve-from/dep.js",
-  "resolve-from/input.js"
+  "node_modules/resolve-from/index.js",
+  "test/unit/resolve-from/dep.js",
+  "test/unit/resolve-from/input.js"
 ]

--- a/test/unit/return-emission/output.js
+++ b/test/unit/return-emission/output.js
@@ -1,4 +1,4 @@
 [
-  "return-emission/asset.txt",
-  "return-emission/input.js"
+  "test/unit/return-emission/asset.txt",
+  "test/unit/return-emission/input.js"
 ]

--- a/test/unit/syntax-err/output.js
+++ b/test/unit/syntax-err/output.js
@@ -1,3 +1,3 @@
 [
-  "syntax-err/input.js"
+  "test/unit/syntax-err/input.js"
 ]

--- a/test/unit/ts-filter/output.js
+++ b/test/unit/ts-filter/output.js
@@ -1,5 +1,5 @@
 [
-  "ts-filter/input.js",
-  "ts-filter/node_modules/pkg/index.js",
-  "ts-filter/node_modules/pkg/index.ts"
+  "test/unit/ts-filter/input.js",
+  "test/unit/ts-filter/node_modules/pkg/index.js",
+  "test/unit/ts-filter/node_modules/pkg/index.ts"
 ]

--- a/test/unit/tsx/output.js
+++ b/test/unit/tsx/output.js
@@ -1,5 +1,5 @@
 [
-  "tsx/dep.tsx",
-  "tsx/input.js",
-  "tsx/lib.ts"
+  "test/unit/tsx/dep.tsx",
+  "test/unit/tsx/input.js",
+  "test/unit/tsx/lib.ts"
 ]

--- a/test/unit/when-wrapper/output.js
+++ b/test/unit/when-wrapper/output.js
@@ -1,4 +1,4 @@
 [
-  "when-wrapper/dep.js",
-  "when-wrapper/input.js"
+  "test/unit/when-wrapper/dep.js",
+  "test/unit/when-wrapper/input.js"
 ]

--- a/test/unit/wildcard-require/output.js
+++ b/test/unit/wildcard-require/output.js
@@ -1,6 +1,6 @@
 [
-  "wildcard-require/input.js",
-  "wildcard-require/modules/module1.js",
-  "wildcard-require/modules/module2.js",
-  "wildcard-require/modules/module3.js"
+  "test/unit/wildcard-require/input.js",
+  "test/unit/wildcard-require/modules/module1.js",
+  "test/unit/wildcard-require/modules/module2.js",
+  "test/unit/wildcard-require/modules/module3.js"
 ]

--- a/test/unit/wildcard/output.js
+++ b/test/unit/wildcard/output.js
@@ -1,6 +1,6 @@
 [
-  "wildcard/assets/asset1.txt",
-  "wildcard/assets/asset2.txt",
-  "wildcard/assets/asset3.txt",
-  "wildcard/input.js"
+  "test/unit/wildcard/assets/asset1.txt",
+  "test/unit/wildcard/assets/asset2.txt",
+  "test/unit/wildcard/assets/asset3.txt",
+  "test/unit/wildcard/input.js"
 ]

--- a/test/unit/wildcard2/output.js
+++ b/test/unit/wildcard2/output.js
@@ -1,4 +1,4 @@
 [
-  "wildcard2/assets/asset1.txt",
-  "wildcard2/input.js"
+  "test/unit/wildcard2/assets/asset1.txt",
+  "test/unit/wildcard2/input.js"
 ]

--- a/test/unit/wildcard3/output.js
+++ b/test/unit/wildcard3/output.js
@@ -1,6 +1,6 @@
 [
-  "wildcard3/assets/asset1.txt",
-  "wildcard3/assets/asset2.txt",
-  "wildcard3/assets/asset3.txt",
-  "wildcard3/input.js"
+  "test/unit/wildcard3/assets/asset1.txt",
+  "test/unit/wildcard3/assets/asset2.txt",
+  "test/unit/wildcard3/assets/asset3.txt",
+  "test/unit/wildcard3/input.js"
 ]

--- a/test/unit/yarn-workspaces/actual.js
+++ b/test/unit/yarn-workspaces/actual.js
@@ -1,6 +1,0 @@
-[
-  "yarn-workspaces/input.js",
-  "yarn-workspaces/packages/x/dep.js",
-  "yarn-workspaces/packages/x/main.js",
-  "yarn-workspaces/packages/x/package.json"
-]

--- a/test/unit/yarn-workspaces/output.js
+++ b/test/unit/yarn-workspaces/output.js
@@ -1,7 +1,7 @@
 [
-  "yarn-workspaces/input.js",
-  "yarn-workspaces/node_modules/x",
-  "yarn-workspaces/packages/x/dep.js",
-  "yarn-workspaces/packages/x/main.js",
-  "yarn-workspaces/packages/x/package.json"
+  "test/unit/yarn-workspaces/input.js",
+  "test/unit/yarn-workspaces/node_modules/x",
+  "test/unit/yarn-workspaces/packages/x/dep.js",
+  "test/unit/yarn-workspaces/packages/x/main.js",
+  "test/unit/yarn-workspaces/packages/x/package.json"
 ]


### PR DESCRIPTION
This makes the `base` option mandatory and deprecates the `filterBase` option as well.

If users really want to have no base, then set `base: '/'` and be aware that you can emit any file on the entire file system. So this doesn't stop that from happening, but just makes it clearer.

By default `base` is set to `process.cwd()`.

Fixes https://github.com/zeit/node-file-trace/issues/6.