### PR TITLE
Fix tests to run in band + verbose

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "./src/node-file-trace.js",
   "types": "./node-file-trace.d.ts",
   "scripts": {
-    "test": "jest",
-    "test-coverage": "jest --coverage --globals \"{\\\"coverage\\\":true}\" && codecov"
+    "test": "jest --runInBand --verbose",
+    "test-coverage": "jest --runInBand --verbose --coverage --globals \"{\\\"coverage\\\":true}\" && codecov"
   },
   "files": [
     "node-file-trace.d.ts",

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -13,7 +13,7 @@ const { fork } = require('child_process');
 
 const tmpdir = path.resolve(os.tmpdir(), 'node-file-trace');
 
-jest.setTimeout(100000);
+jest.setTimeout(200000);
 
 for (const integrationTest of fs.readdirSync(`${__dirname}/integration`)) {
   it(`should correctly trace and correctly execute ${integrationTest}`, async () => {


### PR DESCRIPTION
We use these settings in the [now-builders](https://github.com/zeit/now-builders/blob/0d04440f0f8fc6c3dd6bd9cf8886528c5d3ca5db/package.json#L21) repo because there are sometimes problems running tests concurrently.

This seems to fix the broken tests on master.