### PR TITLE
Support tsx resolution tracing

### DIFF
--- a/src/resolve-dependency.js
+++ b/src/resolve-dependency.js
@@ -22,6 +22,7 @@ function resolveFile (path, job) {
   if (path.endsWith('/')) return;
   if (job.readFile(path) !== null) return path;
   if (job.ts && path.startsWith(job.base) && path.substr(job.base.length).indexOf(sep + 'node_modules' + sep) === -1 && job.readFile(path + '.ts') !== null) return path + '.ts';
+  if (job.ts && path.startsWith(job.base) && path.substr(job.base.length).indexOf(sep + 'node_modules' + sep) === -1 && job.readFile(path + '.tsx') !== null) return path + '.tsx';
   if (job.readFile(path + '.js') !== null) return path + '.js';
   if (job.readFile(path + '.json') !== null) return path + '.json';
   if (job.readFile(path + '.node') !== null) return path + '.node';

--- a/test/unit/tsx/dep.tsx
+++ b/test/unit/tsx/dep.tsx
@@ -1,0 +1,1 @@
+import './lib';

--- a/test/unit/tsx/input.js
+++ b/test/unit/tsx/input.js
@@ -1,0 +1,1 @@
+require('./dep');

--- a/test/unit/tsx/lib.ts
+++ b/test/unit/tsx/lib.ts
@@ -1,0 +1,1 @@
+included

--- a/test/unit/tsx/lib.tsx
+++ b/test/unit/tsx/lib.tsx
@@ -1,0 +1,1 @@
+not included

--- a/test/unit/tsx/output.js
+++ b/test/unit/tsx/output.js
@@ -1,0 +1,5 @@
+[
+  "tsx/dep.tsx",
+  "tsx/input.js",
+  "tsx/lib.ts"
+]


### PR DESCRIPTION
This adds support for `.tsx` file resolution tracing.

We could also consider adding a `jsx: true` option similarly if this is desired for `now-node`.

This should resolve the issue seen in https://github.com/zeit/node-file-trace/issues/10, although there may also be a resolver component of that issue in the now/node integration there too.