### PR TITLE
Add support for mixed ESM and CJS via `mixedModules` flag

### DIFF
--- a/node-file-trace.d.ts
+++ b/node-file-trace.d.ts
@@ -3,6 +3,7 @@ interface NodeFileTraceOptions {
   ignore?: string | string[] | ((path: string) => boolean);
   ts?: boolean;
   log?: boolean;
+  mixedModules?: boolean;
   readFile?: (path: string) => Buffer | string | null;
   stat?: (path: string) => Object | null;
   readlink?: (path: string) => string | null;

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -222,7 +222,7 @@ module.exports = async function (id, code, job) {
     }
   });
 
-  if (!isESM) {
+  if (true) {
     knownBindings.require = {
       shadowDepth: 0,
       value: {
@@ -261,7 +261,7 @@ module.exports = async function (id, code, job) {
     return binding && binding.shadowDepth === 0;
   }
 
-  if (isESM) {
+  if (true) {
     for (const decl of ast.body) {
       if (decl.type === 'ImportDeclaration') {
         const source = decl.source.value;
@@ -424,13 +424,13 @@ module.exports = async function (id, code, job) {
       // - nodegyp()
       // - etc.
       else if (node.type === 'CallExpression') {
-        if (!isESM && node.callee.type === 'Identifier' && node.arguments.length) {
+        if (node.callee.type === 'Identifier' && node.arguments.length) {
           if (node.callee.name === 'require' && knownBindings.require.shadowDepth === 0) {
             processRequireArg(node.arguments[0]);
             return;
           }
         }
-        else if (!isESM &&
+        else if (
             node.callee.type === 'MemberExpression' &&
             node.callee.object.type === 'Identifier' &&
             node.callee.object.name === 'module' &&
@@ -615,7 +615,7 @@ module.exports = async function (id, code, job) {
         }
       }
       // Support require wrappers like function p (x) { ...; var y = require(x); ...; return y;  }
-      else if (!isESM &&
+      else if (
                (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') &&
                (node.arguments || node.params)[0] && (node.arguments || node.params)[0].type === 'Identifier') {
         let fnName, args;

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -222,7 +222,7 @@ module.exports = async function (id, code, job) {
     }
   });
 
-  if (true) {
+  if (!isESM || job.mixedModules) {
     knownBindings.require = {
       shadowDepth: 0,
       value: {
@@ -261,7 +261,7 @@ module.exports = async function (id, code, job) {
     return binding && binding.shadowDepth === 0;
   }
 
-  if (true) {
+  if (isESM || job.mixedModules) {
     for (const decl of ast.body) {
       if (decl.type === 'ImportDeclaration') {
         const source = decl.source.value;
@@ -424,13 +424,13 @@ module.exports = async function (id, code, job) {
       // - nodegyp()
       // - etc.
       else if (node.type === 'CallExpression') {
-        if (node.callee.type === 'Identifier' && node.arguments.length) {
+        if ((!isESM || job.mixedModules) && node.callee.type === 'Identifier' && node.arguments.length) {
           if (node.callee.name === 'require' && knownBindings.require.shadowDepth === 0) {
             processRequireArg(node.arguments[0]);
             return;
           }
         }
-        else if (
+        else if ((!isESM || job.mixedModules) &&
             node.callee.type === 'MemberExpression' &&
             node.callee.object.type === 'Identifier' &&
             node.callee.object.name === 'module' &&
@@ -615,7 +615,7 @@ module.exports = async function (id, code, job) {
         }
       }
       // Support require wrappers like function p (x) { ...; var y = require(x); ...; return y;  }
-      else if (
+      else if ((!isESM || job.mixedModules) &&
                (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') &&
                (node.arguments || node.params)[0] && (node.arguments || node.params)[0].type === 'Identifier') {
         let fnName, args;

--- a/src/node-file-trace.js
+++ b/src/node-file-trace.js
@@ -43,7 +43,8 @@ class Job {
   constructor ({
     base = process.cwd(),
     ignore,
-    log = false
+    log = false,
+    mixedModules = false,
   }) {
     base = resolve(base);
     this.ignoreFn = path => {
@@ -68,6 +69,7 @@ class Job {
     }
     this.base = base;
     this.log = log;
+    this.mixedModules = mixedModules;
     this.reasons = Object.create(null);
 
     this.fileCache = new Map();

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -29,6 +29,7 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
       base: `${__dirname}/../`,
       ts: true,
       log: true,
+      mixedModules: true,
       ignore: '**/actual.js'
     });
     let expected;

--- a/test/unit/mixed-esm-cjs/commonjs-module.js
+++ b/test/unit/mixed-esm-cjs/commonjs-module.js
@@ -1,0 +1,1 @@
+module.exports = { dep1: 'dep1' };

--- a/test/unit/mixed-esm-cjs/ecmascript-module.js
+++ b/test/unit/mixed-esm-cjs/ecmascript-module.js
@@ -1,0 +1,1 @@
+export const dep2 = 'dep2';

--- a/test/unit/mixed-esm-cjs/input.js
+++ b/test/unit/mixed-esm-cjs/input.js
@@ -1,0 +1,7 @@
+const { dep1 } = require('./commonjs-module');
+import { dep2 } from './ecmascript-module';
+
+if (dep1 && dep2) {
+    console.log(dep1);
+    console.log(dep2);
+}

--- a/test/unit/mixed-esm-cjs/input.js
+++ b/test/unit/mixed-esm-cjs/input.js
@@ -2,6 +2,6 @@ const { dep1 } = require('./commonjs-module');
 import { dep2 } from './ecmascript-module';
 
 if (dep1 && dep2) {
-    console.log(dep1);
-    console.log(dep2);
+  console.log(dep1);
+  console.log(dep2);
 }

--- a/test/unit/mixed-esm-cjs/output.js
+++ b/test/unit/mixed-esm-cjs/output.js
@@ -1,0 +1,5 @@
+[
+    "test/unit/mixed-esm-cjs/commonjs-module.js",
+    "test/unit/mixed-esm-cjs/ecmascript-module.js",
+    "test/unit/mixed-esm-cjs/input.js"
+  ]

--- a/test/unit/require-esm/input.js
+++ b/test/unit/require-esm/input.js
@@ -1,3 +1,0 @@
-export default 'asdf';
-
-const dep = require('./dep');

--- a/test/unit/require-esm/output.js
+++ b/test/unit/require-esm/output.js
@@ -1,3 +1,0 @@
-[
-  "test/unit/require-esm/input.js"
-]


### PR DESCRIPTION
This adds support for mixing ESM and CJS so that we have feature parity with `ncc`, which is basically `webpack`.

This will fix all the issues that were reported in the latest release:

- https://spectrum.chat/zeit/general/now-deploys-suddenly-not-working~a052cb8f-e95e-4eef-9e81-5e799d1e5ef4
- https://spectrum.chat/zeit/now/did-you-forget-to-add-it-to-dependencies-in-package-json~6b370740-866c-4404-bdcc-cc51a3bc9aec
- https://spectrum.chat/zeit/now/cannot-build-ts-api-with-now-node-anymore~a24f6eb3-201a-4ecb-8688-94b4a56d4abe
- https://github.com/zeit/now-builders/issues/791


## Update

I spoke with Timer and it sounds like Next.js might want to follow the Node.js behavior. If that's the case maybe we don't want this PR to land. We need to discuss with the whole team.

Perhaps we should enable backwards compatibility through a `config` flag like `mixedModules: true`. That way user's who have broken deployments can opt-in to this behavior.