### PR TITLE
Add lucleray to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Documentation
 # https://help.github.com/en/articles/about-code-owners
 
-*                 @guybedford @styfle
+*                 @lucleray @styfle


### PR DESCRIPTION
We need to make sure PRs are reviewed before merging.

Adding Luc to codeowners.