### PR TITLE
Fix esm export wildcard/asterisk syntax, ie `ExportAllDeclaration`

### DIFF
--- a/src/analyze.js
+++ b/src/analyze.js
@@ -278,7 +278,7 @@ module.exports = async function (id, code, job) {
           }
         }
       }
-      else if (decl.type === 'ExportNamedDeclaration') {
+      else if (decl.type === 'ExportNamedDeclaration' || decl.type === 'ExportAllDeclaration') {
         if (decl.source) deps.add(decl.source.value);
       }
     }

--- a/test/unit/esm-export-wildcard/all.js
+++ b/test/unit/esm-export-wildcard/all.js
@@ -1,0 +1,1 @@
+export * from './week';

--- a/test/unit/esm-export-wildcard/input.js
+++ b/test/unit/esm-export-wildcard/input.js
@@ -1,0 +1,3 @@
+import {mon, wed, fri} from './all';
+
+console.log(mon, wed, fri);

--- a/test/unit/esm-export-wildcard/output.js
+++ b/test/unit/esm-export-wildcard/output.js
@@ -1,0 +1,5 @@
+[
+  "test/unit/esm-export-wildcard/all.js",
+  "test/unit/esm-export-wildcard/input.js",
+  "test/unit/esm-export-wildcard/week.js"
+]

--- a/test/unit/esm-export-wildcard/week.js
+++ b/test/unit/esm-export-wildcard/week.js
@@ -1,0 +1,5 @@
+export const mon = 'mon';
+export const tue = 'tues';
+export const wed = 'wed';
+export const thu = 'thu';
+export const fri = 'fri';


### PR DESCRIPTION
This PR fixes the syntax `export * from './week'` which should include week.js in the output files.

Related to https://github.com/zeit/now-builders/issues/851