### PR TITLE
Fix windows symlink so it doesn't throw

### DIFF
--- a/src/node-file-trace.js
+++ b/src/node-file-trace.js
@@ -96,7 +96,7 @@ class Job {
       return link;
     }
     catch (e) {
-      if (e.code !== 'EINVAL' && e.code !== 'ENOENT')
+      if (e.code !== 'EINVAL' && e.code !== 'ENOENT' && e.code !== 'UNKNOWN')
         throw e;
       this.symlinkCache.set(path, null);
       return null;


### PR DESCRIPTION
I tested this one on Windows and it fixes the issue described in https://github.com/zeit/now-builders/issues/855

We will need to add CI for Windows in order to prevent regressions.