### PR TITLE
Use windows image for azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,12 +2,13 @@
 # Build a general Node.js project with npm.
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
 
 trigger:
 - master
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'windows-2019'
 
 steps:
 - task: NodeTool@0
@@ -16,6 +17,7 @@ steps:
   displayName: 'Install Node.js'
 
 - script: |
-    npm install
-    npm run test
-  displayName: 'npm install and test'
+    node azure-prepare.js
+    yarn install
+    yarn test
+  displayName: 'yarn install and test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,4 +20,4 @@ steps:
     node azure-prepare.js
     yarn install
     yarn test
-  displayName: 'yarn install and test'
+  displayName: 'Install Dependencies & Test'

--- a/azure-prepare.js
+++ b/azure-prepare.js
@@ -1,0 +1,21 @@
+const { unlinkSync, readFileSync, writeFileSync } = require('fs');
+const { join } = require('path');
+
+if (process.platform === 'win32') {
+  // Delete the integration tests that will never work in Windows
+  // because those packages were designed for Linux.
+  const pkgJson = readFileSync(join(__dirname, 'package.json'), 'utf8');
+  const pkg = JSON.parse(pkgJson);
+  unlinkSync(join(__dirname, 'yarn.lock'));
+  unlinkSync(join(__dirname, 'test', 'integration', 'tensorflow.js'));
+  unlinkSync(join(__dirname, 'test', 'integration', 'highlights.js'));
+  unlinkSync(join(__dirname, 'test', 'integration', 'hot-shots.js'));
+  unlinkSync(join(__dirname, 'test', 'integration', 'yoga-layout.js'));
+  delete pkg.devDependencies['@tensorflow/tfjs-node'];
+  delete pkg.devDependencies['highlights'];
+  delete pkg.devDependencies['hot-shots'];
+  delete pkg.devDependencies['yoga-layout'];
+  writeFileSync(join(__dirname, 'package.json'), JSON.stringify(pkg));
+} else {
+  console.log('[azure-prepare] Expected current platform to be win32 but found ' + process.platform);
+}


### PR DESCRIPTION
This fixes azure pipelines so we can test `node-file-trace` in Windows CI.

Prior to this PR, you can see how the CI fails as-is on the `yarn install` step: https://dev.azure.com/zeit-builds/Node.js%20File%20Trace/_build/results?buildId=1016

This PR removes integration tests (only when running Windows CI) that don't support windows. For example, some spawn `rsync` and make assumptions about the system.