### PR TITLE
Support webpack-style Node requires

### DIFF
--- a/src/analyze.js
+++ b/src/analyze.js
@@ -357,7 +357,7 @@ module.exports = async function (id, code, job) {
     if (typeof computed.value === 'string') {
       if (!computed.wildcards)
         deps.add(computed.value);
-      else if (computed.wildcards.length === 1)
+      else if (computed.wildcards.length >= 1)
         emitWildcardRequire(computed.value);
     }
     else {

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -172,11 +172,11 @@ module.exports = async function (id, code, job) {
     assetEmissionPromises = assetEmissionPromises.then(async () => {
       if (job.log)
         console.log('Globbing ' + assetDirPath + wildcardPattern);
-      const files = (await new Promise((resolve, reject) => 
+      const files = (await new Promise((resolve, reject) =>
         glob(assetDirPath + wildcardPattern, { mark: true, ignore: assetDirPath + '/**/node_modules/**/*' }, (err, files) => err ? reject(err) : resolve(files))
       ));
       files
-      .filter(name => 
+      .filter(name =>
         !excludeAssetExtensions.has(path.extname(name)) &&
         !excludeAssetFiles.has(path.basename(name)) &&
         !name.endsWith('/')
@@ -306,9 +306,9 @@ module.exports = async function (id, code, job) {
 
   function emitWildcardRequire (wildcardRequire) {
     if (!wildcardRequire.startsWith('./') && !wildcardRequire.startsWith('../')) return;
-    
+
     wildcardRequire = path.resolve(dir, wildcardRequire);
-    
+
     const wildcardIndex = wildcardRequire.indexOf(WILDCARD);
     const dirIndex = wildcardIndex === -1 ? wildcardRequire.length : wildcardRequire.lastIndexOf(path.sep, wildcardIndex);
     const wildcardDirPath = wildcardRequire.substr(0, dirIndex);
@@ -326,7 +326,7 @@ module.exports = async function (id, code, job) {
     assetEmissionPromises = assetEmissionPromises.then(async () => {
       if (job.log)
         console.log('Globbing ' + wildcardDirPath + wildcardPattern);
-      const files = (await new Promise((resolve, reject) => 
+      const files = (await new Promise((resolve, reject) =>
         glob(wildcardDirPath + wildcardPattern, { mark: true, ignore: wildcardDirPath + '/**/node_modules/**/*' }, (err, files) => err ? reject(err) : resolve(files))
       ));
       files
@@ -348,12 +348,12 @@ module.exports = async function (id, code, job) {
     if (expression.type === 'LogicalExpression') {
       processRequireArg(expression.left);
       processRequireArg(expression.right);
-      return;      
+      return;
     }
 
     let computed = computePureStaticValue(expression, true);
     if (!computed) return;
-    
+
     if (typeof computed.value === 'string') {
       if (!computed.wildcards)
         deps.add(computed.value);

--- a/src/utils/static-eval.js
+++ b/src/utils/static-eval.js
@@ -260,7 +260,17 @@ const visitors = {
     if (node.property.type === 'Identifier') {
       if (typeof obj.value === 'object' && obj.value !== null) {
         if (node.computed) {
-          return { value: WILDCARD, wildcards: [node] };
+          // See if we can compute the computed property
+          const computedProp = walk(node.property);
+          if (computedProp && computedProp.value) {
+            const val = obj.value[computedProp.value];
+            if (val === UNKNOWN) return;
+            return { value: v };
+          }
+          // Special case for empty object
+          if (!obj.value[UNKNOWN] && Object.keys(obj).length === 0) {
+            return { value: undefined };
+          }
         }
         else if (node.property.name in obj.value) {
           const val = obj.value[node.property.name];

--- a/src/utils/static-eval.js
+++ b/src/utils/static-eval.js
@@ -265,7 +265,7 @@ const visitors = {
           if (computedProp && computedProp.value) {
             const val = obj.value[computedProp.value];
             if (val === UNKNOWN) return;
-            return { value: v };
+            return { value: val };
           }
           // Special case for empty object
           if (!obj.value[UNKNOWN] && Object.keys(obj).length === 0) {

--- a/src/utils/static-eval.js
+++ b/src/utils/static-eval.js
@@ -152,7 +152,11 @@ const visitors = {
     if (typeof fn === 'object' && fn !== null) fn = fn[FUNCTION];
     if (typeof fn !== 'function') return;
 
-    const ctx = node.callee.object && walk(node.callee.object).value || null;
+    let ctx = null
+    if (node.callee.object) {
+      ctx = walk(node.callee.object)
+      ctx = ctx && ctx.value ? ctx.value : null
+    }
 
     // we allow one conditional argument to create a conditional expression
     let predicate;

--- a/test/unit/webpack-node/input.js
+++ b/test/unit/webpack-node/input.js
@@ -1,0 +1,3 @@
+const page = require('./level1/level2/level3/page')
+
+console.log(`${page.getChunk('a')} ${page.getChunk('c')}`)

--- a/test/unit/webpack-node/level1/a.b.js
+++ b/test/unit/webpack-node/level1/a.b.js
@@ -1,0 +1,1 @@
+module.exports = 'hello'

--- a/test/unit/webpack-node/level1/c.d.js
+++ b/test/unit/webpack-node/level1/c.d.js
@@ -1,0 +1,1 @@
+module.exports = 'world'

--- a/test/unit/webpack-node/level1/level2/level3/page.js
+++ b/test/unit/webpack-node/level1/level2/level3/page.js
@@ -1,0 +1,13 @@
+function getChunk(chunkId) {
+  var chunk = require('../../' +
+    ({}[chunkId] || chunkId) +
+    '.' +
+    {
+      a: 'b',
+      c: 'd',
+    }[chunkId] +
+    '.js')
+  return chunk
+}
+
+module.exports = { getChunk }

--- a/test/unit/webpack-node/output.js
+++ b/test/unit/webpack-node/output.js
@@ -1,0 +1,6 @@
+[
+  "test/unit/webpack-node/input.js",
+  "test/unit/webpack-node/level1/a.b.js",
+  "test/unit/webpack-node/level1/c.d.js",
+  "test/unit/webpack-node/level1/level2/level3/page.js"
+]


### PR DESCRIPTION
This patches multiple bugs with our static evaluator:
- `MemberExpression` did not handle `computed: true` properties when encountered
- `BinaryExpression` returned wrong value for `A || UNKNOWN -> A if A is truthy` case
- `ObjectExpression` did not wrap computed value in `{ value: ... }` for `walk` compatibility

The sum of these changes allow us to support webpack-style `target: 'node'` emitted `require`s!