### PR TITLE
Prevent CI for tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     - '!*'
   pull_request:
     paths:
-    - '**/*'
+    - '*'
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - master
     tags:
-    - !*
+    - '!*'
   pull_request:
     paths:
     - '**/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - '!*'
+  pull_request:
+    paths:
+    - '*'
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - master
+    tags:
+    - !*
   pull_request:
     paths:
     - '**/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
     - master
-    tags:
-    - '!*'
   pull_request:
     paths:
     - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches:
-    - master
-    tags:
-    - '!*'
-  pull_request:
-    paths:
-    - '*'
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
     tags:
     - '!*'
   pull_request:
-    paths:
-    - '*'
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - master
+    tags:
+    - '!*'
   pull_request:
     paths:
     - '*'


### PR DESCRIPTION
Per @ethomson, we can prevent double runs by disabling CI for tags.

https://twitter.com/ethomson/status/1163497426570764288?s=20