### PR TITLE
Add warning on parser error

### DIFF
--- a/src/analyze.js
+++ b/src/analyze.js
@@ -196,7 +196,8 @@ module.exports = async function (id, code, job) {
     isESM = false;
   }
   catch (e) {
-    if (job.log) {
+    const isModule = e && e.message && e.message.includes('sourceType: module');
+    if (job.log && !isModule) {
       console.log(`Failed to parse ${id} as script:\n${e && e.message}`);
     }
   }

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -190,15 +190,14 @@ module.exports = async function (id, code, job) {
   // remove shebang
   code = code.replace(/^#![^\n\r]*[\r\n]/, '');
 
-  let ast, isESM, parserError;
+  let ast, isESM;
   try {
     ast = acorn.parse(code, { allowReturnOutsideFunction: true });
     isESM = false;
   }
   catch (e) {
-    parserError = e;
     if (job.log) {
-      console.log(`Failed to parse ${id} as script:\n${e.message}`);
+      console.log(`Failed to parse ${id} as script:\n${e && e.message}`);
     }
   }
   if (!ast) {
@@ -207,16 +206,12 @@ module.exports = async function (id, code, job) {
       isESM = true;
     }
     catch (e) {
-      parserError = e;
       if (job.log) {
-        console.log(`Failed to parse ${id} as module:\n${e.message}`);
+        console.log(`Failed to parse ${id} as module:\n${e && e.message}`);
       }
+      // Parser errors just skip analysis
+      return { assets, deps, isESM: false };
     }
-  }
-
-  if (parserError) {
-    // Parser errors just skip analysis
-    return { assets, deps, isESM: false };
   }
 
   const knownBindings = Object.assign(Object.create(null), {

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -197,8 +197,8 @@ module.exports = async function (id, code, job) {
   }
   catch (e) {
     const isModule = e && e.message && e.message.includes('sourceType: module');
-    if (job.log && !isModule) {
-      console.log(`Failed to parse ${id} as script:\n${e && e.message}`);
+    if (!isModule) {
+      job.warnings.add(new Error(`Failed to parse ${id} as script:\n${e && e.message}`));
     }
   }
   if (!ast) {
@@ -207,9 +207,7 @@ module.exports = async function (id, code, job) {
       isESM = true;
     }
     catch (e) {
-      if (job.log) {
-        console.log(`Failed to parse ${id} as module:\n${e && e.message}`);
-      }
+      job.warnings.add(new Error(`Failed to parse ${id} as module:\n${e && e.message}`));
       // Parser errors just skip analysis
       return { assets, deps, isESM: false };
     }

--- a/src/node-file-trace.js
+++ b/src/node-file-trace.js
@@ -222,7 +222,7 @@ class Job {
           if (resolved.startsWith('node:')) return;
         }
         catch (e) {
-          this.warnings.add(e);
+          this.warnings.add(new Error(`Failed to resolve dependency ${dep}:\n${e && e.message}`));
           return;
         }
         await this.emitDependency(resolved, path);


### PR DESCRIPTION
Today, any time acorn fails to parse a source file, it skips the file and there is no way to tell if the bug is acorn or the user has a syntax error. This PR adds a warning when acorn fails to parse the source file.

I confirmed this emits a warning with `fast-glob` (mentioned in #55).

```js
const trace = require('/Users/styfle/Code/zeit/node-file-trace');

trace(['fast-glob/out/index.js'], {
  ts: true,
  mixedModules: true,
  log: true
}).then(o => {
  console.log('FILELIST:')
  console.log(o.fileList.join('\n'));
  console.log('\n');
  if (o.warnings.length > 0) {
    console.log('WARNINGS:');
    console.log(o.warnings);
  }
}).catch(e => { 
  console.error(e)
});

```