### PR TITLE
Add firebase/database to integration test

### DIFF
--- a/test/integration/firebase.js
+++ b/test/integration/firebase.js
@@ -1,6 +1,6 @@
 const firebase = require('firebase/app')
 require('firebase/firestore')
-//require('firebase/database')
+require('firebase/database')
 
 firebase.initializeApp({ projectId: 'noop' })
 const store = firebase.firestore()

--- a/test/integration/firebase.js
+++ b/test/integration/firebase.js
@@ -1,5 +1,6 @@
 const firebase = require('firebase/app')
 require('firebase/firestore')
+//require('firebase/database')
 
 firebase.initializeApp({ projectId: 'noop' })
 const store = firebase.firestore()


### PR DESCRIPTION
Closes #58

It turns out this is not a bug in `@zeit/node-file-trace` but in fact, a bug with `@now/next` which is why it was failing at build time with webpack errors.

Changing from `@now/next` to `@now/node` works.

Let's just add this test to make sure we don't ever regress.