### PR TITLE
Add @Timer to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Documentation
 # https://help.github.com/en/articles/about-code-owners
 
-*                 @lucleray @styfle
+*                 @lucleray @styfle @Timer


### PR DESCRIPTION
Since this package is used for `@now/next`, we should have a Next.js code owner too.