### PR TITLE
Add support for dynamic `import()` expressions

### DIFF
--- a/src/analyze.js
+++ b/src/analyze.js
@@ -436,6 +436,10 @@ module.exports = async function (id, code, job) {
             return;
           }
         }
+        else if ((isESM || job.mixedModules) && node.callee.type === 'Import' && node.arguments.length) {
+          processRequireArg(node.arguments[0]);
+          return;
+        }
         else if ((!isESM || job.mixedModules) &&
             node.callee.type === 'MemberExpression' &&
             node.callee.object.type === 'Identifier' &&

--- a/test/unit/esm-dynamic-import/dep.js
+++ b/test/unit/esm-dynamic-import/dep.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/test/unit/esm-dynamic-import/input.js
+++ b/test/unit/esm-dynamic-import/input.js
@@ -1,0 +1,4 @@
+async function main() {
+  const { foo } = await import('./dep.js');
+  console.log(foo);
+}

--- a/test/unit/esm-dynamic-import/output.js
+++ b/test/unit/esm-dynamic-import/output.js
@@ -1,0 +1,4 @@
+[
+  "test/unit/esm-dynamic-import/dep.js",
+  "test/unit/esm-dynamic-import/input.js"
+]

--- a/test/unit/esm-dynamic-import/package.json
+++ b/test/unit/esm-dynamic-import/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}


### PR DESCRIPTION
This PR adds support for dynamic `import()` expressions.

### Documentation

- [Node.js Docs](https://nodejs.org/api/esm.html#esm_code_import_code_expressions)
- [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Imports)