### PR TITLE
Add experimental CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "license": "MIT",
   "main": "./src/node-file-trace.js",
   "types": "./node-file-trace.d.ts",
+  "bin": {
+    "nft": "./src/cli.js"
+  },
   "scripts": {
     "test": "jest --verbose",
     "test-verbose": "jest --verbose --coverage --globals \"{\\\"coverage\\\":true}\"",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,19 +1,45 @@
 #!/usr/bin/env node
-const trace = require('./node-file-trace');
-const files = process.argv.slice(2);
 
-trace(files, {
-  ts: true,
-  mixedModules: true,
-  log: true
-}).then(o => {
-  console.log('FILELIST:')
-  console.log(o.fileList.join('\n'));
-  console.log('\n');
-  if (o.warnings.length > 0) {
-    console.log('WARNINGS:');
-    console.log(o.warnings);
+const { join, dirname } = require('path');
+const fs = require('fs');
+const { promisify } = require('util');
+const copyFile = promisify(fs.copyFile);
+const mkdir = promisify(fs.mkdir);
+const trace = require('./node-file-trace');
+
+async function main() {
+  const cwd = process.cwd();
+  const action = process.argv[2];
+  const files = process.argv.slice(3);
+  const outputDir = 'dist';
+
+  const { fileList, esmFileList } = await trace(files, {
+    ts: true,
+    mixedModules: true,
+    log: true
+  });
+
+  const allFiles = fileList.concat(esmFileList);
+
+  if (action === 'print') {
+    console.log('FILELIST:')
+    console.log(allFiles.join('\n'));
+    console.log('\n');
+    if (o.warnings.length > 0) {
+      console.log('WARNINGS:');
+      console.log(o.warnings);
+    }
+  } else if (action === 'build') {
+    for (const f of allFiles) {
+      const src = join(cwd, f);
+      const dest = join(cwd, outputDir, f);
+      const dir = dirname(dest);
+      await mkdir(dir, { recursive: true });
+      await copyFile(src, dest);
+    }
+  } else {
+    console.log('Provide an action like `nft build` or `nft print`.');
   }
-}).catch(e => {
-  console.error(e)
-});
+}
+
+main().then(() => console.log('Done')).catch(e => console.error(e));

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,12 +5,14 @@ const fs = require('fs');
 const { promisify } = require('util');
 const copyFile = promisify(fs.copyFile);
 const mkdir = promisify(fs.mkdir);
+const rimraf = require('rimraf');
 const trace = require('./node-file-trace');
 
 async function cli(
   action = process.argv[2],
   files = process.argv.slice(3),
   outputDir = 'dist',
+  cwd = process.cwd()
   ) {
   const opts = {
     ts: true,
@@ -31,6 +33,7 @@ async function cli(
       stdout.push(...warnings);
     }
   } else if (action === 'build') {
+    rimraf.sync(join(cwd, outputDir));
     for (const f of allFiles) {
       const src = join(cwd, f);
       const dest = join(cwd, outputDir, f);
@@ -39,7 +42,7 @@ async function cli(
       await copyFile(src, dest);
     }
   } else {
-    stdout.push('Provide an action like `nft build` or `nft print`.');
+    stdout.push('△ nft - provide an action such as `nft build` or `nft print`.');
   }
   return stdout.join('\n');
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+const trace = require('./node-file-trace');
+const files = process.argv.slice(2);
+
+trace(files, {
+  ts: true,
+  mixedModules: true,
+  log: true
+}).then(o => {
+  console.log('FILELIST:')
+  console.log(o.fileList.join('\n'));
+  console.log('\n');
+  if (o.warnings.length > 0) {
+    console.log('WARNINGS:');
+    console.log(o.warnings);
+  }
+}).catch(e => {
+  console.error(e)
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -20,7 +20,7 @@ it('should correctly print trace from cli', async () => {
   if (stderr) {
     throw new Error(stderr);
   }
-  expect(normalizeOutput(stdout)).toMatch(outputjs);
+  expect(stdout).toMatch(normalizeOutput(outputjs));
 });
 
 it('should correctly build dist from cli', async () => {
@@ -37,7 +37,7 @@ it('should correctly print help when unknown action is used', async () => {
   if (stderr) {
     throw new Error(stderr);
   }
-  expect(normalizeOutput(stdout)).toMatch('provide an action');
+  expect(stdout).toMatch('provide an action');
 });
 
 it('[codecov] should correctly print trace from required cli', async () => {
@@ -45,7 +45,7 @@ it('[codecov] should correctly print trace from required cli', async () => {
   const cli = require('../src/cli.js')
   const files = [join(__dirname, inputjs)];
   const stdout = await cli('print', files);
-  expect(normalizeOutput(stdout)).toMatch(outputjs);
+  expect(stdout).toMatch(normalizeOutput(outputjs));
 });
 
 it('[codecov] should correctly build dist from required cli', async () => {
@@ -62,5 +62,5 @@ it('[codecov] should correctly print help when unknown action is used', async ()
   const cli = require('../src/cli.js')
   const files = [join(__dirname, inputjs)];
   const stdout = await cli('unknown', files);
-  expect(normalizeOutput(stdout)).toMatch('provide an action');
+  expect(stdout).toMatch('provide an action');
 });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -16,7 +16,7 @@ function normalizeOutput(output) {
 }
 
 it('should correctly print trace from cli', async () => {
-  const { stderr, stdout } = await exec(`../src/cli.js print ${inputjs}`, { cwd: __dirname });
+  const { stderr, stdout } = await exec(`node ../src/cli.js print ${inputjs}`, { cwd: __dirname });
   if (stderr) {
     throw new Error(stderr);
   }
@@ -24,7 +24,7 @@ it('should correctly print trace from cli', async () => {
 });
 
 it('should correctly build dist from cli', async () => {
-  const { stderr } = await exec(`../src/cli.js build ${inputjs}`, { cwd: __dirname });
+  const { stderr } = await exec(`node ../src/cli.js build ${inputjs}`, { cwd: __dirname });
   if (stderr) {
     throw new Error(stderr);
   }
@@ -33,7 +33,7 @@ it('should correctly build dist from cli', async () => {
 });
 
 it('should correctly print help when unknown action is used', async () => {
-  const { stderr, stdout } = await exec(`../src/cli.js unknown ${inputjs}`, { cwd: __dirname });
+  const { stderr, stdout } = await exec(`node ../src/cli.js unknown ${inputjs}`, { cwd: __dirname });
   if (stderr) {
     throw new Error(stderr);
   }
@@ -61,9 +61,6 @@ it('[codecov] should correctly print help when unknown action is used', async ()
   // This test is only here to satisfy code coverage
   const cli = require('../src/cli.js')
   const files = [join(__dirname, inputjs)];
-  await cli('unknown', files);
-  if (stderr) {
-    throw new Error(stderr);
-  }
+  const stdout = await cli('unknown', files);
   expect(normalizeOutput(stdout)).toMatch('provide an action');
 });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,22 @@
+const { promisify } = require('util');
+const { exec: _exec } = require('child_process');
+const exec = promisify(_exec);
+
+const inputjs = 'unit/wildcard/input.js';
+const outputjs = 'unit/wildcard/assets/asset1.txt'; 
+
+it('should correctly print trace from cli', async () => {
+  const { stderr, stdout } = await exec(`../src/cli.js print ${inputjs}`, { cwd: __dirname });
+  if (stderr){
+    throw new Error(stderr);
+  }
+  expect(stdout).toMatch(outputjs);
+});
+
+it('should correctly print trace from required cli', async () => {
+  // This is to satisfy code coverage
+  const cli = require('../src/cli.js');
+  const files = [__dirname + '/' + inputjs];
+  const stdout = await cli('print', files);
+  expect(stdout).toMatch(outputjs);
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -3,20 +3,28 @@ const { exec: _exec } = require('child_process');
 const exec = promisify(_exec);
 
 const inputjs = 'unit/wildcard/input.js';
-const outputjs = 'unit/wildcard/assets/asset1.txt'; 
+const outputjs = 'unit/wildcard/assets/asset1.txt';
+
+function normalizeOutput(output) {
+  if (process.platform === 'win32') {
+  // When using Windows, the expected output should use backslash
+    output = output.map(str => str.replace(/\//g, '\\'));
+  }
+  return output;
+}
 
 it('should correctly print trace from cli', async () => {
   const { stderr, stdout } = await exec(`../src/cli.js print ${inputjs}`, { cwd: __dirname });
   if (stderr){
     throw new Error(stderr);
   }
-  expect(stdout).toMatch(outputjs);
+  expect(normalizeOutput(stdout)).toMatch(outputjs);
 });
 
 it('should correctly print trace from required cli', async () => {
-  // This is to satisfy code coverage
+  // This test is only here to satisfy code coverage
   const cli = require('../src/cli.js');
   const files = [__dirname + '/' + inputjs];
   const stdout = await cli('print', files);
-  expect(stdout).toMatch(outputjs);
+  expect(normalizeOutput(stdout)).toMatch(outputjs);
 });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -23,14 +23,6 @@ it('should correctly print trace from cli', async () => {
   expect(normalizeOutput(stdout)).toMatch(outputjs);
 });
 
-it('should correctly print trace from required cli', async () => {
-  // This test is only here to satisfy code coverage
-  const cli = require('../src/cli.js')
-  const files = [join(__dirname, inputjs)];
-  const stdout = await cli('print', files);
-  expect(normalizeOutput(stdout)).toMatch(outputjs);
-});
-
 it('should correctly build dist from cli', async () => {
   const { stderr } = await exec(`../src/cli.js build ${inputjs}`, { cwd: __dirname });
   if (stderr) {
@@ -41,7 +33,35 @@ it('should correctly build dist from cli', async () => {
 });
 
 it('should correctly print help when unknown action is used', async () => {
-  const { stderr, stdout } = await exec(`../src/cli.js nothing ${inputjs}`, { cwd: __dirname });
+  const { stderr, stdout } = await exec(`../src/cli.js unknown ${inputjs}`, { cwd: __dirname });
+  if (stderr) {
+    throw new Error(stderr);
+  }
+  expect(normalizeOutput(stdout)).toMatch('provide an action');
+});
+
+it('[codecov] should correctly print trace from required cli', async () => {
+  // This test is only here to satisfy code coverage
+  const cli = require('../src/cli.js')
+  const files = [join(__dirname, inputjs)];
+  const stdout = await cli('print', files);
+  expect(normalizeOutput(stdout)).toMatch(outputjs);
+});
+
+
+it('[codecov] should correctly build dist from required cli', async () => {
+  // This test is only here to satisfy code coverage
+  const cli = require('../src/cli.js')
+  const files = [join(__dirname, inputjs)];
+  await cli('build', files);
+  const found = existsSync(join(__dirname, outputjs));
+  expect(found).toBe(true);
+});
+
+it('[codecov] should correctly print help when unknown action is used', async () => {
+  const cli = require('../src/cli.js')
+  const files = [join(__dirname, inputjs)];
+  await cli('unknown', files);
   if (stderr) {
     throw new Error(stderr);
   }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -10,7 +10,7 @@ const outputjs = 'unit/wildcard/assets/asset1.txt';
 function normalizeOutput(output) {
   if (process.platform === 'win32') {
     // When using Windows, the expected output should use backslash
-    output = output.map(str => str.replace(/\//g, '\\'));
+    output = output.replace(/\//g, '\\');
   }
   return output;
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -9,7 +9,7 @@ const outputjs = 'unit/wildcard/assets/asset1.txt';
 
 function normalizeOutput(output) {
   if (process.platform === 'win32') {
-  // When using Windows, the expected output should use backslash
+    // When using Windows, the expected output should use backslash
     output = output.map(str => str.replace(/\//g, '\\'));
   }
   return output;
@@ -48,7 +48,6 @@ it('[codecov] should correctly print trace from required cli', async () => {
   expect(normalizeOutput(stdout)).toMatch(outputjs);
 });
 
-
 it('[codecov] should correctly build dist from required cli', async () => {
   // This test is only here to satisfy code coverage
   const cli = require('../src/cli.js')
@@ -59,6 +58,7 @@ it('[codecov] should correctly build dist from required cli', async () => {
 });
 
 it('[codecov] should correctly print help when unknown action is used', async () => {
+  // This test is only here to satisfy code coverage
   const cli = require('../src/cli.js')
   const files = [join(__dirname, inputjs)];
   await cli('unknown', files);


### PR DESCRIPTION
I often use this script when debugging so might as well add it as a CLI.

- `nft print index.js` - useful for debugging by printing to stdout
- `nft build index.js` - similar to ncc which will generate a `dist` directory

This will be released as experimental and the output could change at any time without following semver.