### PR TITLE
Skip bull test when connection string is missing

### DIFF
--- a/test/integration/bull.js
+++ b/test/integration/bull.js
@@ -1,11 +1,12 @@
-const Queue = require('bull');
 const { BULL_REDIS_CONNECTION } = process.env;
 
 if (!BULL_REDIS_CONNECTION) {
   console.log('Skipping bull integration test');
   console.log('Create cache on redislabs.com and export BULL_REDIS_CONNECTION="redis://:password@hostname:port"');
+  return;
 }
 
+const Queue = require('bull');
 const pdfQueue = new Queue('pdf transcoding', BULL_REDIS_CONNECTION);
 
 pdfQueue.process(function(job, done) {


### PR DESCRIPTION
Follow up to #82 

This will skip the bull integration test if the environment variable secret is not found.

This happens when a PR is submitted from someone outside the ZEIT GitHub Org and GH Actions omits secrets from CI.