### PR TITLE
Add special case for semver@7

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "redis": "^2.8.0",
     "rxjs": "^6.5.2",
     "saslprep": "^1.0.3",
+    "semver": "^7.1.1",
     "sequelize": "^5.9.3",
     "sharp": "^0.22.1",
     "socket.io": "^2.2.0",

--- a/src/utils/special-cases.js
+++ b/src/utils/special-cases.js
@@ -68,6 +68,12 @@ const specialCases = {
       emitAssetDirectory(path.resolve(path.dirname(id), '..', 'bin'));
     }
   },
+  'semver' ({ id, emitAsset }) {
+    if (id.endsWith('semver/index.js')) {
+      // See https://github.com/npm/node-semver/blob/master/CHANGELOG.md#710
+      emitAsset(path.resolve(id.replace('index.js', 'preload.js')));
+    }
+  },
   'socket.io' ({ id, ast }) {
     if (id.endsWith('socket.io/lib/index.js')) {
       function replaceResolvePathStatement (statement) {

--- a/test/integration/semver.js
+++ b/test/integration/semver.js
@@ -1,0 +1,9 @@
+const semver = require('semver');
+
+const v1 = '1.0.0';
+const v2 = '2.0.0';
+
+semver.gt(v1, v2);
+semver.lt(v1, v2);
+semver.eq(v1, v2);
+semver.coerce(v1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9397,7 +9397,6 @@ npm@^6.13.4:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -9412,7 +9411,6 @@ npm@^6.13.4:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.5"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -9431,14 +9429,8 @@ npm@^6.13.4:
     libnpx "^10.2.0"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -11672,6 +11664,11 @@ semver@^6.0.0, semver@^6.1.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.2.0.tgz#4d813d9590aaf8a9192693d6c85b9344de5901db"
   integrity sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==
+
+semver@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
+  integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
 
 semver@~5.3.0:
   version "5.3.0"


### PR DESCRIPTION
The `semver` package changed in version 7 to use a [dynamic/lazy loading](https://github.com/npm/node-semver/pull/295) index file.

I first first spotted this breaking change in [Package Phobia](https://github.com/styfle/packagephobia/pull/494).

This PR adds a special case to statically analyze the `preload.js` entry point which is effectively what the `index.js` entry point used to be prior to version 7.

See the [changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md):

> Add require('semver/preload') to load the entire module without using lazy getter methods.
