### PR TITLE
Add missing builtins

### DIFF
--- a/src/resolve-dependency.js
+++ b/src/resolve-dependency.js
@@ -54,7 +54,7 @@ function notFound (specifier, parent) {
   throw e;
 }
 
-const nodeBuiltins = new Set([...require("repl")._builtinLibs, "constants", "module", "timers", "console", "_stream_writable", "_stream_readable", "_stream_duplex"]);
+const nodeBuiltins = new Set([...require("repl")._builtinLibs, "constants", "module", "timers", "console", "_stream_writable", "_stream_readable", "_stream_duplex", "process", "sys"]);
 
 function resolvePackage (name, parent, job) {
   let packageParent = parent;


### PR DESCRIPTION
Currently `process` and `sys` give errors, when they are valid Node.js builtins (since they are not listed by repl).

This adds them as exceptions to avoid the unnecessary warning messages.