### PR TITLE
Fixup dot dot require

### DIFF
--- a/src/resolve-dependency.js
+++ b/src/resolve-dependency.js
@@ -5,7 +5,7 @@ const { isAbsolute, resolve, sep } = require('path');
 // (package.json files are emitted as they are hit)
 module.exports = function resolveDependency (specifier, parent, job) {
   let resolved;
-  if (isAbsolute(specifier) || specifier === '.' || specifier.startsWith('./') || specifier.startsWith('../'))
+  if (isAbsolute(specifier) || specifier === '.' || specifier === '..' || specifier.startsWith('./') || specifier.startsWith('../'))
     resolved = resolvePath(resolve(parent, '..', specifier), parent, job);
   else
     resolved = resolvePackage(specifier, parent, job);

--- a/test/unit/dot-dot/dir/dot-dot-req.js
+++ b/test/unit/dot-dot/dir/dot-dot-req.js
@@ -1,0 +1,1 @@
+module.exports = require('..');

--- a/test/unit/dot-dot/index.js
+++ b/test/unit/dot-dot/index.js
@@ -1,0 +1,1 @@
+module.exports = 'dot dot';

--- a/test/unit/dot-dot/input.js
+++ b/test/unit/dot-dot/input.js
@@ -1,0 +1,1 @@
+require('./dir/dot-dot-req.js');

--- a/test/unit/dot-dot/output.js
+++ b/test/unit/dot-dot/output.js
@@ -1,0 +1,5 @@
+[
+  "test/unit/dot-dot/dir/dot-dot-req.js",
+  "test/unit/dot-dot/index.js",
+  "test/unit/dot-dot/input.js"
+]


### PR DESCRIPTION
This fixes up tracing for `require('..')` without a trailing slash, which was resulting in some inaccurate analysis.