### PR TITLE
Allow configurable analysis

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,30 @@ const { fileList } = await nodeFileTrace(['index.ts'], {
 }
 ```
 
+#### Analysis
+
+Analysis options allow customizing how much analysis should be performed to exactly work out the dependency list.
+
+By default as much analysis as possible is done to ensure no possibly needed files are left out of the trace.
+
+To disable all analysis, set `analysis: false`. Alternatively, individual analysis options can be customized via:
+
+```js
+const { fileList } = await nodeFileTrace(files, {
+  // default
+  analysis: {
+    // whether to glob any analysis like __dirname + '/dir/' or require('x/' + y)
+    // that might output any file in a directory
+    emitGlobs: true,
+    // whether __filename and __dirname style
+    // expressions should be analyzed as file references
+    computeFileReferences: true,
+    // evaluate known bindings to assist with glob and file reference analysis
+    evaluatePureExpressions: true,
+  }
+});
+```
+
 #### Ignore
 
 Custom ignores can be provided to skip file inclusion (and consequently analysis of the file for references in turn as well).

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -165,6 +165,7 @@ module.exports = async function (id, code, job) {
   const pkgBase = getPackageBase(id);
 
   const emitAssetDirectory = (wildcardPath) => {
+    if (!job.analysis.emitGlobs) return;
     const wildcardIndex = wildcardPath.indexOf(WILDCARD);
     const dirIndex = wildcardIndex === -1 ? wildcardPath.length : wildcardPath.lastIndexOf(path.sep, wildcardIndex);
     const assetDirPath = wildcardPath.substr(0, dirIndex);
@@ -318,7 +319,7 @@ module.exports = async function (id, code, job) {
   let definedExpressEngines = false;
 
   function emitWildcardRequire (wildcardRequire) {
-    if (!wildcardRequire.startsWith('./') && !wildcardRequire.startsWith('../')) return;
+    if (!job.analysis.emitGlobs || !wildcardRequire.startsWith('./') && !wildcardRequire.startsWith('../')) return;
 
     wildcardRequire = path.resolve(dir, wildcardRequire);
 
@@ -417,7 +418,7 @@ module.exports = async function (id, code, job) {
       if (staticChildNode) return;
 
       if (node.type === 'Identifier') {
-        if (isIdentifierRead(node, parent)) {
+        if (isIdentifierRead(node, parent) && job.analysis.computeFileReferences) {
           let binding;
           // detect asset leaf expression triggers (if not already)
           // __dirname,  __filename
@@ -436,7 +437,7 @@ module.exports = async function (id, code, job) {
       // - bindings()(...)
       // - nodegyp()
       // - etc.
-      else if (node.type === 'CallExpression') {
+      else if (node.type === 'CallExpression' && job.analysis.evaluatePureExpressions) {
         if ((!isESM || job.mixedModules) && node.callee.type === 'Identifier' && node.arguments.length) {
           if (node.callee.name === 'require' && knownBindings.require.shadowDepth === 0) {
             processRequireArg(node.arguments[0]);
@@ -463,7 +464,7 @@ module.exports = async function (id, code, job) {
         const calleeValue = computePureStaticValue(node.callee, false);
         // if we have a direct pure static function,
         // and that function has a [TRIGGER] symbol -> trigger asset emission from it
-        if (calleeValue && typeof calleeValue.value === 'function' && calleeValue.value[TRIGGER]) {
+        if (calleeValue && typeof calleeValue.value === 'function' && calleeValue.value[TRIGGER] && job.analysis.computeFileReferences) {
           staticChildValue = computePureStaticValue(node, true);
           // if it computes, then we start backtracking
           if (staticChildValue) {
@@ -541,7 +542,7 @@ module.exports = async function (id, code, job) {
               definedExpressEngines = true;
             break;
             case FS_FN:
-              if (node.arguments[0]) {
+              if (node.arguments[0] && job.analysis.computeFileReferences) {
                 staticChildValue = computePureStaticValue(node.arguments[0], true);
                 // if it computes, then we start backtracking
                 if (staticChildValue) {
@@ -572,7 +573,7 @@ module.exports = async function (id, code, job) {
           }
         }
       }
-      else if (node.type === 'VariableDeclaration' && !isVarLoop(parent)) {
+      else if (node.type === 'VariableDeclaration' && !isVarLoop(parent) && job.analysis.evaluatePureExpressions) {
         for (const decl of node.declarations) {
           if (!decl.init) continue;
           const computed = computePureStaticValue(decl.init, false);
@@ -602,7 +603,7 @@ module.exports = async function (id, code, job) {
           }
         }
       }
-      else if (node.type === 'AssignmentExpression' && !isLoop(parent)) {
+      else if (node.type === 'AssignmentExpression' && !isLoop(parent) && job.analysis.evaluatePureExpressions) {
         if (!hasKnownBindingValue(node.left.name)) {
           const computed = computePureStaticValue(node.right, false);
           if (computed && 'value' in computed) {

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -437,7 +437,7 @@ module.exports = async function (id, code, job) {
       // - bindings()(...)
       // - nodegyp()
       // - etc.
-      else if (node.type === 'CallExpression' && job.analysis.evaluatePureExpressions) {
+      else if (node.type === 'CallExpression') {
         if ((!isESM || job.mixedModules) && node.callee.type === 'Identifier' && node.arguments.length) {
           if (node.callee.name === 'require' && knownBindings.require.shadowDepth === 0) {
             processRequireArg(node.arguments[0]);
@@ -461,7 +461,7 @@ module.exports = async function (id, code, job) {
           return;
         }
 
-        const calleeValue = computePureStaticValue(node.callee, false);
+        const calleeValue = job.analysis.evaluatePureExpressions && computePureStaticValue(node.callee, false);
         // if we have a direct pure static function,
         // and that function has a [TRIGGER] symbol -> trigger asset emission from it
         if (calleeValue && typeof calleeValue.value === 'function' && calleeValue.value[TRIGGER] && job.analysis.computeFileReferences) {

--- a/src/node-file-trace.js
+++ b/src/node-file-trace.js
@@ -45,6 +45,7 @@ class Job {
     ignore,
     log = false,
     mixedModules = false,
+    analysis = {},
   }) {
     base = resolve(base);
     this.ignoreFn = path => {
@@ -71,6 +72,20 @@ class Job {
     this.log = log;
     this.mixedModules = mixedModules;
     this.reasons = Object.create(null);
+
+    this.analysis = {};
+    if (analysis !== false) {
+      Object.assign(this.analysis, {
+        // whether to glob any analysis like __dirname + '/dir/' or require('x/' + y)
+        // that might output any file in a directory
+        emitGlobs: true,
+        // whether __filename and __dirname style
+        // expressions should be analyzed as file references
+        computeFileReferences: true,
+        // evaluate known bindings to assist with glob and file reference analysis
+        evaluatePureExpressions: true,
+      }, analysis === true ? {} : analysis);
+    }
 
     this.fileCache = new Map();
     this.statCache = new Map();

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -53,6 +53,8 @@ for (const unitTest of fs.readdirSync(join(__dirname, 'unit'))) {
       base: `${__dirname}/../`,
       ts: true,
       log: true,
+      // disable analysis for basic-analysis unit tests
+      analysis: !unitTest.startsWith('basic-analysis'),
       mixedModules: true,
       ignore: '**/actual.js',
       readFile: readFileMock

--- a/test/unit/basic-analysis-require/dep.js
+++ b/test/unit/basic-analysis-require/dep.js
@@ -1,0 +1,1 @@
+module.exports = 'dep';

--- a/test/unit/basic-analysis-require/input.js
+++ b/test/unit/basic-analysis-require/input.js
@@ -1,0 +1,1 @@
+require('./dep');

--- a/test/unit/basic-analysis-require/output.js
+++ b/test/unit/basic-analysis-require/output.js
@@ -1,0 +1,4 @@
+[
+  "test/unit/basic-analysis-require/dep.js",
+  "test/unit/basic-analysis-require/input.js"
+]


### PR DESCRIPTION
This PR allows a new `analysis` option permitting an object of analysis features to turn on or off.

Useful for when the full expression analysis isn't needed and a fast-pass analysis is suitable.