### PR TITLE
Implement simple cache persistence between traces

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,21 @@ Ignore will also accept a function or globs.
 
 Note that the path provided to ignore is relative to `base`.
 
+#### Cache
+
+To persist the file cache between builds, pass an empty `cache` object:
+
+```js
+const cache = Object.create(null);
+const { fileList } = await nodeFileTrace(['index.ts'], { cache });
+// later:
+{
+  const { fileList } = await nodeFileTrace(['index.ts'], { cache });
+}
+```
+
+Note that cache invalidations are not supported so the assumption is that the file system is not changed between runs.
+
 #### Reasons
 
 To get the underlying reasons for individual files being included, a `reasons` object is also provided by the output:

--- a/src/node-file-trace.js
+++ b/src/node-file-trace.js
@@ -76,11 +76,13 @@ class Job {
     this.fileCache = cache && cache.fileCache || new Map();
     this.statCache = cache && cache.statCache || new Map();
     this.symlinkCache = cache && cache.symlinkCache || new Map();
+    this.analysisCache = cache && cache.analysisCache || new Map();
 
     if (cache) {
       cache.fileCache = this.fileCache;
       cache.statCache = this.statCache;
       cache.symlinkCache = this.symlinkCache;
+      cache.analysisCache = this.analysisCache;
     }
 
     this.fileList = new Set();
@@ -203,14 +205,22 @@ class Job {
 
     const emitted = this.emitFile(path, 'dependency', parent);
     if (!emitted) return;
-  
     if (path.endsWith('.json')) return;
     if (path.endsWith('.node')) return await sharedlibEmit(path, this);
 
-    const source = this.readFile(path);
-    if (source === null) throw new Error('File ' + path + ' does not exist.');
+    let deps, assets, isESM;
 
-    const { deps, assets, isESM } = await analyze(path, source, this);
+    const cachedAnalysis = this.analysisCache.get(path);
+    if (cachedAnalysis) {
+      ({ deps, assets, isESM } = cachedAnalysis);
+    }
+    else {
+      const source = this.readFile(path);
+      if (source === null) throw new Error('File ' + path + ' does not exist.');
+      ({ deps, assets, isESM } = await analyze(path, source, this));
+      this.analysisCache.set(path, { deps, assets, isESM });
+    }
+
     if (isESM)
       this.esmFileList.add(relative(this.base, path));
     await Promise.all([

--- a/src/node-file-trace.js
+++ b/src/node-file-trace.js
@@ -45,6 +45,7 @@ class Job {
     ignore,
     log = false,
     mixedModules = false,
+    cache,
   }) {
     base = resolve(base);
     this.ignoreFn = path => {
@@ -72,9 +73,15 @@ class Job {
     this.mixedModules = mixedModules;
     this.reasons = Object.create(null);
 
-    this.fileCache = new Map();
-    this.statCache = new Map();
-    this.symlinkCache = new Map();
+    this.fileCache = cache && cache.fileCache || new Map();
+    this.statCache = cache && cache.statCache || new Map();
+    this.symlinkCache = cache && cache.symlinkCache || new Map();
+
+    if (cache) {
+      cache.fileCache = this.fileCache;
+      cache.statCache = this.statCache;
+      cache.symlinkCache = this.symlinkCache;
+    }
 
     this.fileList = new Set();
     this.esmFileList = new Set();


### PR DESCRIPTION
This provides a `cache` option which stores the stat, symlink and file cache between runs for reuse when the file system is known to not have any changes between runs.