### PR TITLE
Move passport-trakt to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "micromatch": "^4.0.2",
     "mkdirp": "^0.5.1",
     "node-pre-gyp": "^0.13.0",
-    "passport-trakt": "^1.0.4",
     "resolve-from": "^5.0.0",
     "rollup-pluginutils": "^2.8.2"
   },
@@ -89,6 +88,7 @@
     "oracledb": "^3.1.2",
     "passport": "^0.4.0",
     "passport-google-oauth": "^2.0.0",
+    "passport-trakt": "^1.0.4",
     "path-platform": "^0.11.15",
     "pdf2json": "^1.1.8",
     "pdfkit": "^0.10.0",


### PR DESCRIPTION
The `passport-trakt` package is only used for a test, its not needed a runtime.