### PR TITLE
Fix dependency `node-gyp-build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "graceful-fs": "^4.1.15",
     "micromatch": "^4.0.2",
     "mkdirp": "^0.5.1",
+    "node-gyp-build": "^4.2.2",
     "node-pre-gyp": "^0.13.0",
     "resolve-from": "^5.0.0",
     "rollup-pluginutils": "^2.8.2"
@@ -83,7 +84,6 @@
     "memcached": "^2.2.2",
     "mongoose": "^5.7.5",
     "mysql": "^2.17.1",
-    "node-gyp-build": "^4.2.1",
     "npm": "^6.13.4",
     "oracledb": "^4.2.0",
     "passport": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9013,10 +9013,10 @@ node-gyp-build@^4.1.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.1.0.tgz#3bc3dd7dd4aafecaf64a2e3729e785bc3cdea565"
   integrity sha512-rGLv++nK20BG8gc0MzzcYe1Nl3p3mtwJ74Q2QD0HTEDKZ6NvOFSelY6s2QBPWIHRR8h7hpad0LiwajfClBJfNg==
 
-node-gyp-build@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.1.tgz#f28f0d3d3ab268d48ab76c6f446f19bc3d0db9dc"
-  integrity sha512-XyCKXsqZfLqHep1hhsMncoXuUNt/cXCjg1+8CLbu69V1TKuPiOeSGbL9n+k/ByKH8UT0p4rdIX8XkTRZV0i7Sw==
+node-gyp-build@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.2.tgz#3f44b65adaafd42fb6c3d81afd630e45c847eb66"
+  integrity sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==
 
 node-gyp-build@~4.1.0:
   version "4.1.1"


### PR DESCRIPTION
In PR #106 , `node-gyp-build` was added as a devDependency but it needs to be a dependency as seen in this PR https://github.com/zeit/now/pull/4407 that updates `@vercel/node` and `@vercel/next`.